### PR TITLE
AMI updates for JasperReports Server 7.5.0

### DIFF
--- a/templates/tibco-jrs-cluster-existing-infrastructure.template
+++ b/templates/tibco-jrs-cluster-existing-infrastructure.template
@@ -327,22 +327,22 @@
     },
     "Mappings": {
         "AWSAMIRegionMap": {
-            "us-east-1" : { "64" : "ami-06f91cd7d5536aed2"},
-            "us-east-2" : { "64" : "ami-07f4e1c328364f8e4"},
-            "us-west-1" : { "64" : "ami-0f9f10a52ce57e08a"},
-            "us-west-2" : { "64" : "ami-0702731f9db377eb3"},
-            "ca-central-1" : { "64" : "ami-0d62d0215cb127fde"},
-            "eu-central-1" : { "64" : "ami-03416724bb8fbcb29"},
-            "eu-west-1" : { "64" : "ami-04ffae4f29bb4704c"},
-            "eu-west-2" : { "64" : "ami-07db901a8a06212e3"},
-            "eu-west-3" : { "64" : "ami-065a2eb9e4e60fb03"},
-            "eu-north-1" : { "64" : "ami-d255deac"},
-            "ap-southeast-1" : { "64" : "ami-09e028879b48bdf8e"},
-            "ap-southeast-2" : { "64" : "ami-0133968d004c2627a"},
-            "ap-south-1" : { "64" : "ami-05984a0227a13875e"},
-            "ap-northeast-1" : { "64" : "ami-0a707cd6956f3d8a0"},
-            "ap-northeast-2" : { "64" : "ami-0bfcf731282d1dde2"},
-            "sa-east-1" : { "64" : "ami-09383944bc61d70b5"}
+            "us-east-1" : { "64" : "ami-07e1fe71c982efbd0"},
+            "us-east-2" : { "64" : "ami-006a5b311cc3df7fe"},
+            "us-west-1" : { "64" : "ami-0b66f45597597fba2"},
+            "us-west-2" : { "64" : "ami-03d0ae7c0aa0b03e1"},
+            "ca-central-1" : { "64" : "ami-0db5966371975a1e4"},
+            "eu-central-1" : { "64" : "ami-00156f1e923486e87"},
+            "eu-west-1" : { "64" : "ami-03ab7e649660e479d"},
+            "eu-west-2" : { "64" : "ami-02091ebf63fa1a7f0"},
+            "eu-west-3" : { "64" : "ami-0744ce138a0dc9929"},
+            "eu-north-1" : { "64" : "ami-0ff2ac0a6651db2ee"},
+            "ap-southeast-1" : { "64" : "ami-0e970a5500a79bee8"},
+            "ap-southeast-2" : { "64" : "ami-09231f01688a835ec"},
+            "ap-south-1" : { "64" : "ami-05d7d181acc353182"},
+            "ap-northeast-1" : { "64" : "ami-00a2cd8ed572d2e35"},
+            "ap-northeast-2" : { "64" : "ami-0d3319aee4fd7f496"},
+            "sa-east-1" : { "64" : "ami-0f15bfe6af0995b01"}
         }
     },
     "Resources": {

--- a/templates/tibco-jrs-single-instance-existing-infrastructure.template
+++ b/templates/tibco-jrs-single-instance-existing-infrastructure.template
@@ -170,22 +170,22 @@
     },
     "Mappings": {
         "AWSAMIRegionMap": {
-            "us-east-1" : { "64" : "ami-06f91cd7d5536aed2"},
-            "us-east-2" : { "64" : "ami-07f4e1c328364f8e4"},
-            "us-west-1" : { "64" : "ami-0f9f10a52ce57e08a"},
-            "us-west-2" : { "64" : "ami-0702731f9db377eb3"},
-            "ca-central-1" : { "64" : "ami-0d62d0215cb127fde"},
-            "eu-central-1" : { "64" : "ami-03416724bb8fbcb29"},
-            "eu-west-1" : { "64" : "ami-04ffae4f29bb4704c"},
-            "eu-west-2" : { "64" : "ami-07db901a8a06212e3"},
-            "eu-west-3" : { "64" : "ami-065a2eb9e4e60fb03"},
-            "eu-north-1" : { "64" : "ami-d255deac"},
-            "ap-southeast-1" : { "64" : "ami-09e028879b48bdf8e"},
-            "ap-southeast-2" : { "64" : "ami-0133968d004c2627a"},
-            "ap-south-1" : { "64" : "ami-05984a0227a13875e"},
-            "ap-northeast-1" : { "64" : "ami-0a707cd6956f3d8a0"},
-            "ap-northeast-2" : { "64" : "ami-0bfcf731282d1dde2"},
-            "sa-east-1" : { "64" : "ami-09383944bc61d70b5"}
+            "us-east-1" : { "64" : "ami-07e1fe71c982efbd0"},
+            "us-east-2" : { "64" : "ami-006a5b311cc3df7fe"},
+            "us-west-1" : { "64" : "ami-0b66f45597597fba2"},
+            "us-west-2" : { "64" : "ami-03d0ae7c0aa0b03e1"},
+            "ca-central-1" : { "64" : "ami-0db5966371975a1e4"},
+            "eu-central-1" : { "64" : "ami-00156f1e923486e87"},
+            "eu-west-1" : { "64" : "ami-03ab7e649660e479d"},
+            "eu-west-2" : { "64" : "ami-02091ebf63fa1a7f0"},
+            "eu-west-3" : { "64" : "ami-0744ce138a0dc9929"},
+            "eu-north-1" : { "64" : "ami-0ff2ac0a6651db2ee"},
+            "ap-southeast-1" : { "64" : "ami-0e970a5500a79bee8"},
+            "ap-southeast-2" : { "64" : "ami-09231f01688a835ec"},
+            "ap-south-1" : { "64" : "ami-05d7d181acc353182"},
+            "ap-northeast-1" : { "64" : "ami-00a2cd8ed572d2e35"},
+            "ap-northeast-2" : { "64" : "ami-0d3319aee4fd7f496"},
+            "sa-east-1" : { "64" : "ami-0f15bfe6af0995b01"}
         }
     },
     "Resources": {


### PR DESCRIPTION
*AMI Id updates for JasperReports Sever 7.5:*

Using AMIs from JasperReports Server BYOL 7.5 Marketplace listing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
